### PR TITLE
Allow mysql setup to wait with configured credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@
 DATAHUB_GMS=http://localhost:8080
 DATAHUB_TOKEN=
 
+# MySQL credentials used by docker-compose (quote values if they contain special characters)
+MYSQL_ROOT_PASSWORD=rootpass
+MYSQL_DATABASE=datahub
+MYSQL_USER=datahub
+MYSQL_PASSWORD=datahubpass
+
 # Postgres source used in the proof-of-concept
 PG_CONN_STR=postgresql://tokenize:pass@postgres:5432/tokenize
 PG_PK_COLUMN=id

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,22 @@ build:
 	$(COMPOSE) build datahub-actions
 
 up:
-	$(COMPOSE) up -d
-	$(COMPOSE) ps zookeeper
-	@CONTAINER=$$($(COMPOSE) ps -q zookeeper); \
-	if [ -n "$$CONTAINER" ]; then \
+        $(COMPOSE) up -d
+        $(COMPOSE) ps mysql
+        @CONTAINER=$$($(COMPOSE) ps -q mysql); \
+        if [ -n "$$CONTAINER" ]; then \
+                docker inspect --format '{{.State.Health.Status}}' $$CONTAINER | grep -q healthy || { \
+                        $(COMPOSE) logs --no-color mysql datahub-custom-action-mysql-setup || true; \
+                        exit 1; \
+                }; \
+        else \
+                echo "Failed to resolve mysql container"; \
+                $(COMPOSE) logs --no-color mysql datahub-custom-action-mysql-setup || true; \
+                exit 1; \
+        fi
+        $(COMPOSE) ps zookeeper
+        @CONTAINER=$$($(COMPOSE) ps -q zookeeper); \
+        if [ -n "$$CONTAINER" ]; then \
 		docker inspect --format '{{.State.Health.Status}}' $$CONTAINER | grep -q healthy || { \
 			$(COMPOSE) logs --no-color zookeeper broker || true; \
 			exit 1; \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you plan to ingest from Databricks, set the Databricks connection variables i
 ```bash
 # Copy defaults and update credentials if needed
 cp .env.example .env
+# When editing MySQL credentials, wrap values in quotes and avoid leading hyphens so YAML parses them correctly
 
 # Build the custom action image and start the stack
 make build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,29 +61,35 @@ services:
   mysql:
     image: mysql:8.0
     environment:
-      MYSQL_DATABASE: datahub
-      MYSQL_ROOT_PASSWORD: datahub
-      MYSQL_USER: datahub
-      MYSQL_PASSWORD: datahub
+      MYSQL_ROOT_PASSWORD: "rootpass"
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_DATABASE: "datahub"
+      MYSQL_USER: "datahub"
+      MYSQL_PASSWORD: "datahubpass"
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -prootpass | grep -q 'mysqld is alive'"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
 
-  mysql-setup:
-    image: acryldata/datahub-mysql-setup:v1.2.0.1
+  datahub-custom-action-mysql-setup:
+    image: mysql:8.0
     depends_on:
       mysql:
         condition: service_healthy
     environment:
-      MYSQL_HOST: mysql
-      MYSQL_PORT: 3306
-      MYSQL_USER: datahub
-      MYSQL_PASSWORD: datahub
-      MYSQL_DB: datahub
+      MYSQL_HOST: "mysql"
+      MYSQL_PORT: "3306"
+      MYSQL_DB: "datahub"
+      MYSQL_USER: "root"
+      MYSQL_PASSWORD: "rootpass"
+    entrypoint: ["/bin/sh","-lc","/wait-mysql.sh \"$MYSQL_HOST\" \"$MYSQL_PORT\" && /scripts/run-setup.sh"]
+    volumes:
+      - ./scripts/wait-mysql.sh:/wait-mysql.sh:ro
+      - ./scripts/run-setup.sh:/scripts/run-setup.sh:ro
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
@@ -121,7 +127,7 @@ services:
   datahub-gms:
     image: acryldata/datahub-gms:v1.2.0.1
     depends_on:
-      mysql-setup:
+      datahub-custom-action-mysql-setup:
         condition: service_completed_successfully
       kafka-setup:
         condition: service_completed_successfully
@@ -136,7 +142,7 @@ services:
       MYSQL_HOST: mysql
       MYSQL_PORT: 3306
       MYSQL_USERNAME: datahub
-      MYSQL_PASSWORD: datahub
+      MYSQL_PASSWORD: "datahubpass"
     ports:
       - "8080:8080"
     healthcheck:

--- a/scripts/run-setup.sh
+++ b/scripts/run-setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+set -euo pipefail
+HOST="${MYSQL_HOST}"
+PORT="${MYSQL_PORT}"
+USER="${MYSQL_USER}"
+PASS="${MYSQL_PASSWORD}"
+
+mysql --protocol=tcp -h "$HOST" -P "$PORT" -u "$USER" --password="$PASS" <<'SQL'
+CREATE DATABASE IF NOT EXISTS `datahub` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+USE `datahub`;
+
+CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (
+  urn            varchar(500) NOT NULL,
+  aspect         varchar(200) NOT NULL,
+  version        bigint(20)   NOT NULL,
+  metadata       longtext     NOT NULL,
+  systemmetadata longtext,
+  createdon      datetime(6)  NOT NULL,
+  createdby      varchar(255) NOT NULL,
+  createdfor     varchar(255),
+  CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn,aspect,version),
+  INDEX timeIndex (createdon)
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+DROP TABLE IF EXISTS temp_metadata_aspect_v2;
+CREATE TABLE temp_metadata_aspect_v2 LIKE metadata_aspect_v2;
+INSERT INTO temp_metadata_aspect_v2 (urn,aspect,version,metadata,systemmetadata,createdon,createdby) VALUES
+('urn:li:corpuser:datahub','corpUserInfo',0,'{"displayName":"Data Hub","active":true,"fullName":"Data Hub","email":"datahub@linkedin.com"}','{}',NOW(6),'urn:li:corpuser:__datahub_system'),
+('urn:li:corpuser:datahub','corpUserEditableInfo',0,'{"skills":[],"teams":[],"pictureLink":"https://raw.githubusercontent.com/datahub-project/datahub/master/datahub-web-react/src/images/default_avatar.png"}','{}',NOW(6),'urn:li:corpuser:__datahub_system');
+
+INSERT INTO metadata_aspect_v2 SELECT * FROM temp_metadata_aspect_v2
+WHERE NOT EXISTS (SELECT 1 FROM metadata_aspect_v2 LIMIT 1);
+DROP TABLE temp_metadata_aspect_v2;
+SQL
+
+# To allow non-root schema initialization runs:
+# mysql --protocol=tcp -h "$HOST" -P "$PORT" -u root --password="$PASS" <<'SQL'
+# CREATE USER IF NOT EXISTS 'datahub'@'%' IDENTIFIED BY 'datahubpass';
+# GRANT ALL PRIVILEGES ON datahub.* TO 'datahub'@'%';
+# FLUSH PRIVILEGES;
+# SQL

--- a/scripts/wait-mysql.sh
+++ b/scripts/wait-mysql.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -e
+
+HOST="${1:?host}"
+PORT="${2:?port}"
+USER="${MYSQL_USER:-root}"
+PASS="${MYSQL_PASSWORD:-}"
+
+for i in $(seq 1 60); do
+  if [ -n "$PASS" ]; then
+    if mysqladmin ping -h "$HOST" -P "$PORT" -u"$USER" --password="$PASS" >/dev/null 2>&1; then
+      exit 0
+    fi
+  else
+    if mysqladmin ping -h "$HOST" -P "$PORT" -u"$USER" >/dev/null 2>&1; then
+      exit 0
+    fi
+  fi
+  sleep 1
+done
+
+echo "MySQL not healthy" >&2
+exit 1


### PR DESCRIPTION
## Summary
- allow remote access to the MySQL root account so the setup container can authenticate over TCP
- teach the wait script to reuse the configured MySQL credentials instead of hard coded defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2917d7868832cb274e028d3de1ddc