### PR TITLE
Use datahub MySQL user for setup scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,8 +84,8 @@ services:
       MYSQL_HOST: "mysql"
       MYSQL_PORT: "3306"
       MYSQL_DB: "datahub"
-      MYSQL_USER: "root"
-      MYSQL_PASSWORD: "rootpass"
+      MYSQL_USER: "datahub"
+      MYSQL_PASSWORD: "datahubpass"
     entrypoint: ["/bin/sh","-lc","/wait-mysql.sh \"$MYSQL_HOST\" \"$MYSQL_PORT\" && /scripts/run-setup.sh"]
     volumes:
       - ./scripts/wait-mysql.sh:/wait-mysql.sh:ro

--- a/scripts/run-setup.sh
+++ b/scripts/run-setup.sh
@@ -6,7 +6,6 @@ USER="${MYSQL_USER}"
 PASS="${MYSQL_PASSWORD}"
 
 mysql --protocol=tcp -h "$HOST" -P "$PORT" -u "$USER" --password="$PASS" <<'SQL'
-CREATE DATABASE IF NOT EXISTS `datahub` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 USE `datahub`;
 
 CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (


### PR DESCRIPTION
## Summary
- run the MySQL setup helper container using the standard datahub user credentials
- rely on the pre-created datahub database when initializing schema data

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d298fd0628832cb4a314a200ae4837