### PR TITLE
Fix GMS wait dependencies and improve MySQL setup health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       MYSQL_DB: "datahub"
       MYSQL_USER: "datahub"
       MYSQL_PASSWORD: "datahubpass"
+      MYSQL_HEALTH_USER: "root"
+      MYSQL_HEALTH_PASSWORD: "rootpass"
     entrypoint: ["/bin/sh","-lc","/wait-mysql.sh \"$MYSQL_HOST\" \"$MYSQL_PORT\" && /scripts/run-setup.sh"]
     volumes:
       - ./scripts/wait-mysql.sh:/wait-mysql.sh:ro
@@ -143,6 +145,11 @@ services:
       MYSQL_PORT: 3306
       MYSQL_USERNAME: datahub
       MYSQL_PASSWORD: "datahubpass"
+      WAIT_FOR: >
+        http://elasticsearch:9200
+        http://schema-registry:8081
+        tcp://broker:29092
+        tcp://mysql:3306
     ports:
       - "8080:8080"
     healthcheck:

--- a/scripts/wait-mysql.sh
+++ b/scripts/wait-mysql.sh
@@ -3,18 +3,12 @@ set -e
 
 HOST="${1:-host}"
 PORT="${2:-port}"
-USER="${MYSQL_USER:-root}"
-PASS="${MYSQL_PASSWORD:-}"
+USER="${MYSQL_HEALTH_USER:-${MYSQL_USER:-root}}"
+PASS="${MYSQL_HEALTH_PASSWORD:-${MYSQL_PASSWORD:-}}"
 
 for i in $(seq 1 60); do
-  if [ -n "$PASS" ]; then
-    if mysqladmin ping -h "$HOST" -P "$PORT" -u"$USER" --password="$PASS" >/dev/null 2>&1; then
-      exit 0
-    fi
-  else
-    if mysqladmin ping -h "$HOST" -P "$PORT" -u"$USER" >/dev/null 2>&1; then
-      exit 0
-    fi
+  if mysqladmin ping --protocol=tcp -h "$HOST" -P "$PORT" -u"$USER" ${PASS:+--password="$PASS"} >/dev/null 2>&1; then
+    exit 0
   fi
   sleep 1
 done


### PR DESCRIPTION
## Summary
- configure the DataHub GMS container to wait for Kafka, Elasticsearch, Schema Registry, and MySQL endpoints explicitly before starting
- allow the MySQL setup helper to probe health with dedicated credentials and force TCP connections to avoid blank host failures
- provide root credentials for the MySQL health probe while keeping application credentials unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d29dcb1ed8832c8e6cdb6433a8dd1b