### PR TITLE
Stabilize startup waits and idempotency checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-COMPOSE ?= docker compose
+ifndef COMPOSE
+COMPOSE := $(shell if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then echo "docker compose"; fi)
+ifeq ($(strip $(COMPOSE)),)
+COMPOSE := $(shell if command -v docker-compose >/dev/null 2>&1; then echo "docker-compose"; fi)
+endif
+ifeq ($(strip $(COMPOSE)),)
+$(error "docker compose or docker-compose not found. Set COMPOSE=/path/to/binary to override")
+endif
+endif
 DATASET_NAME ?= customers
 DATASET_PLATFORM ?= postgres
 TIMEOUT ?= 600
@@ -63,7 +71,7 @@ verify-idempotent:
 	response = json.loads(sys.argv[1])
 	rows = response.get("rows_updated")
 	if rows not in (0, "0"):
-	raise SystemExit(f"Expected 0 rows updated, got {rows}")
+	    raise SystemExit(f"Expected 0 rows updated, got {rows}")
 	PY
 
 e2e: build up ingest trigger-ui wait-status verify-idempotent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.3
-    platform: ${DOCKER_PLATFORM:-linux/arm64}
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -17,7 +17,7 @@ services:
 
   broker:
     image: confluentinc/cp-kafka:7.5.3
-    platform: ${DOCKER_PLATFORM:-linux/arm64}
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       zookeeper:
         condition: service_healthy
@@ -44,6 +44,7 @@ services:
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.5.3
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       broker:
         condition: service_healthy
@@ -95,6 +96,7 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     environment:
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
@@ -108,6 +110,7 @@ services:
 
   elasticsearch-setup:
     image: acryldata/datahub-elasticsearch-setup:v1.2.0.1
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -117,6 +120,7 @@ services:
 
   kafka-setup:
     image: acryldata/datahub-kafka-setup:v1.2.0.1
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       broker:
         condition: service_healthy
@@ -128,6 +132,7 @@ services:
 
   datahub-gms:
     image: acryldata/datahub-gms:v1.2.0.1
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       datahub-custom-action-mysql-setup:
         condition: service_completed_successfully
@@ -145,11 +150,8 @@ services:
       MYSQL_PORT: 3306
       MYSQL_USERNAME: datahub
       MYSQL_PASSWORD: "datahubpass"
-      WAIT_FOR: >
-        http://elasticsearch:9200
-        http://schema-registry:8081
-        tcp://broker:29092
-        tcp://mysql:3306
+      EBEAN_DATASOURCE_HOST: mysql:3306
+      WAIT_FOR_URIS: "http://elasticsearch:9200/_cluster/health http://schema-registry:8081/subjects tcp://broker:29092 tcp://mysql:3306"
     ports:
       - "8080:8080"
     healthcheck:
@@ -157,9 +159,18 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+    volumes:
+      - ./scripts/wait-for-uris.sh:/wait-for-uris.sh:ro
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        /wait-for-uris.sh
+        exec /datahub/datahub-gms/scripts/start.sh
 
   datahub-frontend:
     image: acryldata/datahub-frontend-react:v1.2.0.1
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       datahub-gms:
         condition: service_healthy
@@ -178,6 +189,7 @@ services:
 
   datahub-mce-consumer:
     image: acryldata/datahub-mce-consumer:v1.2.0.1
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       datahub-gms:
         condition: service_healthy
@@ -190,6 +202,7 @@ services:
 
   datahub-mae-consumer:
     image: acryldata/datahub-mae-consumer:v1.2.0.1
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     depends_on:
       datahub-gms:
         condition: service_healthy
@@ -225,6 +238,7 @@ services:
       KAFKA_BOOTSTRAP_SERVER: broker:29092
       KAFKA_SCHEMA_REGISTRY_URL: http://schema-registry:8081
       PG_CONN_STR: postgresql://tokenize:pass@postgres:5432/tokenize
+      WAIT_FOR_URIS: "http://datahub-gms:8080/health http://schema-registry:8081/subjects tcp://broker:29092 tcp://postgres:5432"
     depends_on:
       datahub-gms:
         condition: service_healthy
@@ -241,3 +255,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        /app/scripts/wait-for-uris.sh
+        exec uvicorn action.app:app --host 0.0.0.0 --port 8081

--- a/docker/action.Dockerfile
+++ b/docker/action.Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential libpq-dev curl \
+    && apt-get install -y --no-install-recommends bash build-essential libpq-dev curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY action/requirements.txt /tmp/requirements.txt

--- a/scripts/seed_pg.sh
+++ b/scripts/seed_pg.sh
@@ -8,7 +8,7 @@ else
   COMPOSE_COMMAND="docker compose"
 fi
 
-${COMPOSE_COMMAND} exec -T postgres psql -U tokenize -d tokenize <<'SQL'
+PGPASSWORD=${PGPASSWORD:-pass} ${COMPOSE_COMMAND} exec -T postgres psql -U tokenize -d tokenize <<'SQL'
 CREATE TABLE IF NOT EXISTS customers (
     id SERIAL PRIMARY KEY,
     email TEXT,

--- a/scripts/wait-for-uris.sh
+++ b/scripts/wait-for-uris.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFS=$' \t\n'
+URIS=("$@")
+if [ ${#URIS[@]} -eq 0 ] && [ -n "${WAIT_FOR_URIS:-}" ]; then
+  # shellcheck disable=SC2206
+  URIS=(${WAIT_FOR_URIS})
+fi
+
+if [ ${#URIS[@]} -eq 0 ]; then
+  echo "wait-for-uris: no URIs provided" >&2
+  exit 0
+fi
+
+check_http() {
+  local url=$1
+  local attempt=0
+  while true; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    echo "wait-for-uris: waiting for $url (attempt $attempt)" >&2
+    sleep 2
+  done
+}
+
+check_tcp() {
+  local target=$1
+  local host=${target%:*}
+  local port=${target##*:}
+  if [[ -z $host || -z $port || $host == $port ]]; then
+    echo "wait-for-uris: invalid tcp target '$target'" >&2
+    return 1
+  fi
+  local attempt=0
+  while true; do
+    if (echo > /dev/tcp/$host/$port) >/dev/null 2>&1; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    echo "wait-for-uris: waiting for tcp://$target (attempt $attempt)" >&2
+    sleep 2
+  done
+}
+
+for raw in "${URIS[@]}"; do
+  uri=$(echo "$raw" | xargs)
+  [ -z "$uri" ] && continue
+  case "$uri" in
+    http://*|https://*)
+      check_http "$uri"
+      ;;
+    tcp://*)
+      check_tcp "${uri#tcp://}"
+      ;;
+    *)
+      echo "wait-for-uris: unsupported URI '$uri'" >&2
+      exit 1
+      ;;
+  esac
+done


### PR DESCRIPTION
## Summary
- auto-detect the docker compose binary and fix the Makefile idempotency assertion helper
- add a reusable wait-for-uris helper script and wire it into GMS/action startup along with platform overrides
- ensure the action image ships with bash and seed Postgres via a password-aware exec helper

## Testing
- make build *(fails: docker compose or docker-compose not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a4d0cb88832ca10b2c234c5ac820