### PR TITLE
Add CI pipeline and improve compose health wait

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,40 @@
+name: E2E Tokenization
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare environment file
+        run: cp .env.example .env
+
+      - name: Build custom action image
+        run: make build
+
+      - name: Start services
+        run: make up
+
+      - name: Ingest sample dataset
+        run: make ingest
+
+      - name: Trigger tokenization via UI workflow
+        run: |
+          make trigger-ui
+          make wait-status
+          make verify-idempotent
+
+      - name: Capture docker logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Tear down stack
+        if: always()
+        run: make down

--- a/Makefile
+++ b/Makefile
@@ -17,33 +17,33 @@ build:
 	$(COMPOSE) build datahub-actions
 
 up:
-	$(COMPOSE) up -d
-	$(COMPOSE) ps mysql
-	@CONTAINER=$$($(COMPOSE) ps -q mysql); \
-	if [ -n "$$CONTAINER" ]; then \
-			docker inspect --format '{{.State.Health.Status}}' $$CONTAINER | grep -q healthy || { \
-					$(COMPOSE) logs --no-color mysql datahub-custom-action-mysql-setup || true; \
-					exit 1; \
-			}; \
-	else \
-			echo "Failed to resolve mysql container"; \
-			$(COMPOSE) logs --no-color mysql datahub-custom-action-mysql-setup || true; \
-			exit 1; \
-	fi
-	$(COMPOSE) ps zookeeper
-	@CONTAINER=$$($(COMPOSE) ps -q zookeeper); \
-	if [ -n "$$CONTAINER" ]; then \
-	docker inspect --format '{{.State.Health.Status}}' $$CONTAINER | grep -q healthy || { \
-		$(COMPOSE) logs --no-color zookeeper broker || true; \
-		exit 1; \
-	}; \
-	else \
-	echo "Failed to resolve zookeeper container"; \
-	$(COMPOSE) logs --no-color zookeeper broker || true; \
-	exit 1; \
-	fi
-	$(COMPOSE) wait datahub-gms datahub-actions postgres
-	./scripts/seed_pg.sh
+        $(COMPOSE) up -d
+        $(COMPOSE) ps mysql
+        @CONTAINER=$$($(COMPOSE) ps -q mysql); \
+        if [ -n "$$CONTAINER" ]; then \
+                        docker inspect --format '{{.State.Health.Status}}' $$CONTAINER | grep -q healthy || { \
+                                        $(COMPOSE) logs --no-color mysql datahub-custom-action-mysql-setup || true; \
+                                        exit 1; \
+                        }; \
+        else \
+                        echo "Failed to resolve mysql container"; \
+                        $(COMPOSE) logs --no-color mysql datahub-custom-action-mysql-setup || true; \
+                        exit 1; \
+        fi
+        $(COMPOSE) ps zookeeper
+        @CONTAINER=$$($(COMPOSE) ps -q zookeeper); \
+        if [ -n "$$CONTAINER" ]; then \
+        docker inspect --format '{{.State.Health.Status}}' $$CONTAINER | grep -q healthy || { \
+                $(COMPOSE) logs --no-color zookeeper broker || true; \
+                exit 1; \
+        }; \
+        else \
+        echo "Failed to resolve zookeeper container"; \
+        $(COMPOSE) logs --no-color zookeeper broker || true; \
+        exit 1; \
+        fi
+        WAIT_TIMEOUT=$(TIMEOUT) ./scripts/wait-for-health.sh "$(COMPOSE)" datahub-gms datahub-actions postgres
+        ./scripts/seed_pg.sh
 
 ingest:
 	$(COMPOSE) exec -T datahub-actions datahub ingest -c /app/ingestion/postgres.yml

--- a/scripts/wait-for-health.sh
+++ b/scripts/wait-for-health.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Wait for one or more docker compose services to reach a healthy state.
+# Usage: wait-for-health.sh "docker compose" service1 [service2 ...]
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <compose-command> <service> [service...]" >&2
+  exit 1
+fi
+
+COMPOSE_CMD="$1"
+shift
+SERVICES=("$@")
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-600}"
+WAIT_INTERVAL="${WAIT_INTERVAL:-5}"
+
+wait_for_service() {
+  local service="$1"
+  local deadline=$((SECONDS + WAIT_TIMEOUT))
+
+  echo "Waiting for service '$service' to become healthy..."
+  while true; do
+    local container_id
+    container_id=$(${COMPOSE_CMD} ps -q "$service" 2>/dev/null || true)
+    if [ -z "$container_id" ]; then
+      if (( SECONDS >= deadline )); then
+        echo "Timed out waiting for container id for service '$service'." >&2
+        ${COMPOSE_CMD} ps >&2 || true
+        return 1
+      fi
+      sleep "$WAIT_INTERVAL"
+      continue
+    fi
+
+    local status
+    status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)
+
+    case "$status" in
+      healthy|running)
+        echo "Service '$service' is healthy ($status)."
+        return 0
+        ;;
+      unhealthy|exited|dead)
+        echo "Service '$service' reported status '$status'." >&2
+        ${COMPOSE_CMD} logs "$service" >&2 || true
+        return 1
+        ;;
+      "")
+        # Container might be starting up; fall through to retry.
+        ;;
+      *)
+        echo "Service '$service' current status: $status" >&2
+        ;;
+    esac
+
+    if (( SECONDS >= deadline )); then
+      echo "Timed out waiting for service '$service' to become healthy." >&2
+      ${COMPOSE_CMD} logs "$service" >&2 || true
+      return 1
+    fi
+
+    sleep "$WAIT_INTERVAL"
+  done
+}
+
+for svc in "${SERVICES[@]}"; do
+  if ! wait_for_service "$svc"; then
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the end-to-end tokenization flow with docker compose
- replace use of `docker compose wait` with a portable health waiting script and reuse it in `make up`

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68d2a8ede63c832c9c2a71eb8a0c327b