### PR TITLE
Fix ingestion transformer and ensure policy index setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,19 @@ services:
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PORT: 9200
 
+  policy-index-setup:
+    image: curlimages/curl:8.10.1
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c", "/scripts/setup-policy-index.sh"]
+    environment:
+      ELASTICSEARCH_HOST: elasticsearch
+      ELASTICSEARCH_PORT: 9200
+      POLICY_INDEX_NAME: datahubpolicyindex_v2
+    volumes:
+      - ./scripts/setup_policy_index.sh:/scripts/setup-policy-index.sh:ro
+
   kafka-setup:
     image: acryldata/datahub-kafka-setup:v1.2.0.1
     platform: ${DOCKER_PLATFORM:-linux/amd64}
@@ -146,6 +159,8 @@ services:
       kafka-setup:
         condition: service_completed_successfully
       elasticsearch-setup:
+        condition: service_completed_successfully
+      policy-index-setup:
         condition: service_completed_successfully
     environment:
       ENTITY_REGISTRY_CONFIG_PATH: /datahub/datahub-gms/resources/entity-registry.yml

--- a/ingestion/__init__.py
+++ b/ingestion/__init__.py
@@ -1,0 +1,2 @@
+"""Package marker for ingestion helpers."""
+

--- a/ingestion/postgres.yml
+++ b/ingestion/postgres.yml
@@ -14,10 +14,9 @@ source:
     profiling:
       enabled: false
 transformers:
-  - type: simple_add_dataset_tags
+  - type: add_dataset_tags
     config:
-      tag_urns:
-        - "urn:li:tag:tokenize/run"
+      get_tags_to_add: ingestion.tag_helpers.tokenize_run_tags
 sink:
   type: datahub-rest
   config:

--- a/ingestion/tag_helpers.py
+++ b/ingestion/tag_helpers.py
@@ -1,0 +1,14 @@
+"""Helper functions used by ingestion recipes."""
+
+from __future__ import annotations
+
+from typing import List
+
+from datahub.metadata.schema_classes import TagAssociationClass
+
+
+def tokenize_run_tags(_: str) -> List[TagAssociationClass]:
+    """Return the tokenize/run tag association for every dataset."""
+
+    return [TagAssociationClass(tag="urn:li:tag:tokenize/run")]
+

--- a/scripts/setup_policy_index.sh
+++ b/scripts/setup_policy_index.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+HOST="${ELASTICSEARCH_HOST:-elasticsearch}"
+PORT="${ELASTICSEARCH_PORT:-9200}"
+INDEX="${POLICY_INDEX_NAME:-datahubpolicyindex_v2}"
+
+BASE_URL="http://${HOST}:${PORT}"
+
+if curl -sf "${BASE_URL}/${INDEX}" >/dev/null 2>&1; then
+    echo "Index ${INDEX} already exists"
+    exit 0
+fi
+
+echo "Creating index ${INDEX}"
+curl -sf -X PUT "${BASE_URL}/${INDEX}" \
+    -H 'Content-Type: application/json' \
+    -d '{"settings":{"index":{"number_of_shards":1,"number_of_replicas":0}}}'
+
+echo "Created index ${INDEX}"


### PR DESCRIPTION
## Summary
- update the Postgres ingestion recipe to call a helper that adds the tokenize/run tag with the current CLI
- add an ingestion helper module that returns the desired TagAssociation
- ensure the policy index exists by introducing a curl-based setup service and script that runs before GMS starts

## Testing
- make ingest *(fails: "docker compose or docker-compose not found")*


------
https://chatgpt.com/codex/tasks/task_e_68d2f6139674832c9a199451ac12df5f