### PR TITLE
Add datahub-upgrade bootstrap job

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,44 @@ services:
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PORT: 9200
 
+  datahub-upgrade:
+    image: acryldata/datahub-upgrade:v1.2.0.1
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    depends_on:
+      datahub-custom-action-mysql-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      policy-index-setup:
+        condition: service_completed_successfully
+    environment:
+      DATAHUB_SECRET: "7e3dc188888893837378986378937e3dc1"
+      DATAHUB_GMS_HOST: datahub-gms
+      DATAHUB_GMS_PORT: 8080
+      EBEAN_DATASOURCE_HOST: mysql:3306
+      EBEAN_DATASOURCE_USERNAME: datahub
+      EBEAN_DATASOURCE_PASSWORD: "datahubpass"
+      EBEAN_DATASOURCE_URL: >-
+        jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8&enabledTLSProtocols=TLSv1.2
+      KAFKA_BOOTSTRAP_SERVER: broker:29092
+      KAFKA_SCHEMAREGISTRY_URL: http://schema-registry:8081
+      ELASTICSEARCH_HOST: elasticsearch
+      ELASTICSEARCH_PORT: 9200
+      GRAPH_SERVICE_IMPL: elasticsearch
+      ENTITY_REGISTRY_CONFIG_PATH: /datahub/datahub-gms/resources/entity-registry.yml
+      WAIT_FOR_URIS: >-
+        tcp://mysql:3306 http://schema-registry:8081/subjects tcp://broker:29092 http://elasticsearch:9200/_cluster/health
+    volumes:
+      - ./scripts/wait-for-uris.sh:/wait-for-uris.sh:ro
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        /wait-for-uris.sh
+        exec /datahub/datahub-upgrade/scripts/start.sh -u SystemUpdate
+
   policy-index-setup:
     image: curlimages/curl:8.10.1
     depends_on:
@@ -161,6 +199,8 @@ services:
       elasticsearch-setup:
         condition: service_completed_successfully
       policy-index-setup:
+        condition: service_completed_successfully
+      datahub-upgrade:
         condition: service_completed_successfully
     environment:
       ENTITY_REGISTRY_CONFIG_PATH: /datahub/datahub-gms/resources/entity-registry.yml


### PR DESCRIPTION
## Summary
- add a datahub-upgrade one-shot service to bootstrap default metadata and policies before GMS starts
- gate GMS startup on the upgrade job so logins work once bootstrap completes

## Testing
- python -m compileall action

------
https://chatgpt.com/codex/tasks/task_e_68d35257e818832ca7f20f77e554bc9f