### PR TITLE
Configure MySQL driver for DataHub services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,7 @@ services:
       EBEAN_DATASOURCE_HOST: mysql:3306
       EBEAN_DATASOURCE_USERNAME: datahub
       EBEAN_DATASOURCE_PASSWORD: "datahubpass"
+      EBEAN_DATASOURCE_DRIVER: com.mysql.jdbc.Driver
       EBEAN_DATASOURCE_URL: 'jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8&enabledTLSProtocols=TLSv1.2'
       GRAPH_SERVICE_IMPL: elasticsearch
       # Non-interactive (various flags accepted across versions)
@@ -227,6 +228,7 @@ services:
       EBEAN_DATASOURCE_HOST: mysql:3306
       EBEAN_DATASOURCE_USERNAME: datahub
       EBEAN_DATASOURCE_PASSWORD: "datahubpass"
+      EBEAN_DATASOURCE_DRIVER: com.mysql.jdbc.Driver
       EBEAN_DATASOURCE_URL: 'jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8&enabledTLSProtocols=TLSv1.2'
       WAIT_FOR_URIS: >-
         http://elasticsearch:9200/_cluster/health http://schema-registry:8081/subjects tcp://broker:29092 tcp://mysql:3306
@@ -291,6 +293,7 @@ services:
       EBEAN_DATASOURCE_PORT: 3306
       EBEAN_DATASOURCE_USERNAME: datahub
       EBEAN_DATASOURCE_PASSWORD: "datahubpass"
+      EBEAN_DATASOURCE_DRIVER: com.mysql.jdbc.Driver
       GRAPH_SERVICE_IMPL: elasticsearch
       EBEAN_DATASOURCE_URL: 'jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8&enabledTLSProtocols=TLSv1.2'
       WAIT_FOR_URIS: >-
@@ -326,6 +329,7 @@ services:
       EBEAN_DATASOURCE_PORT: 3306
       EBEAN_DATASOURCE_USERNAME: datahub
       EBEAN_DATASOURCE_PASSWORD: "datahubpass"
+      EBEAN_DATASOURCE_DRIVER: com.mysql.jdbc.Driver
       EBEAN_DATASOURCE_URL: 'jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8&enabledTLSProtocols=TLSv1.2'
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PORT: 9200


### PR DESCRIPTION
## Summary
- add the explicit MySQL JDBC driver configuration to the DataHub upgrade, GMS, MAE consumer, and MCE consumer services so Spring can build the Ebean datasource

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d37b00755c832ca7f995c53aab4450