### PR TITLE
Align action API port configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,4 @@ KAFKA_GROUP_ID=tokenization-action
 KAFKA_AUTO_OFFSET_RESET=latest
 
 # FastAPI server configuration
-ACTION_PORT=8081
+ACTION_PORT=8091

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `make e2e` target chains `build → up → ingest → trigger-ui → wait-st
 Send a POST request to the FastAPI endpoint running inside the action container:
 
 ```bash
-curl -X POST http://localhost:8081/trigger \
+curl -X POST http://localhost:8091/trigger \
   -H 'Content-Type: application/json' \
   -d '{
         "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,tokenize.public.customers,PROD)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -383,7 +383,7 @@ services:
       kafka-setup:                      # 👈 add
         condition: service_completed_successfully
     ports:
-      - "8091:8091"
+      - "8091:${ACTION_PORT:-8091}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8091/healthz"]
       interval: 10s
@@ -394,4 +394,4 @@ services:
       - -lc
       - |
         /app/scripts/wait-for-uris.sh
-        exec uvicorn action.app:app --host 0.0.0.0 --port 8091
+        exec uvicorn action.app:app --host 0.0.0.0 --port "${ACTION_PORT:-8091}"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 DATASET_NAME=${DATASET_NAME:-customers}
 PLATFORM=${PLATFORM:-postgres}
 TIMEOUT=${TIMEOUT:-600}
+ACTION_PORT=${ACTION_PORT:-8091}
 
 DATASET_URN=$(python3 scripts/find_dataset_urn.py "$DATASET_NAME" "$PLATFORM" | head -n 1 | cut -f1)
 if [ -z "$DATASET_URN" ]; then
@@ -20,7 +21,7 @@ echo "Resolved dataset URN: $DATASET_URN"
 API_RESPONSE=$(curl -s -X POST \
   -H 'Content-Type: application/json' \
   -d "{\"dataset\": \"$DATASET_URN\"}" \
-  http://localhost:8081/trigger)
+  http://localhost:${ACTION_PORT}/trigger)
 echo "API trigger response: $API_RESPONSE"
 
 ./scripts/poll_status.sh "$DATASET_URN" "$TIMEOUT"


### PR DESCRIPTION
## Summary
- document and script updates to reference the action service on port 8091 instead of schema registry's 8081
- allow overriding the FastAPI port through docker-compose, Makefile, and scripts via ACTION_PORT

## Testing
- bash -n scripts/e2e.sh

------
https://chatgpt.com/codex/tasks/task_e_68d37e238ef4832c83c2fc8972948811